### PR TITLE
arch: riscv: add an option for empty spurious interrupt handler

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -225,6 +225,13 @@ config RISCV_RESERVED_IRQ_ISR_TABLES_OFFSET
 	  properly sized to take into account this offset. This is a hidden
 	  option which needs to be set per architecture and left alone.
 
+config RISCV_EMPTY_IRQ_SPURIOUS
+	bool "Create empty spurious interrupt handler"
+	help
+	  This option changes body of spurious interrupt handler. When enabled,
+	  handler contains only an infinite while loop, when disabled, handler
+	  contains the whole Zephyr fault handling procedure.
+
 config NUM_IRQS
 	int
 

--- a/arch/riscv/core/irq_manage.c
+++ b/arch/riscv/core/irq_manage.c
@@ -19,6 +19,12 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 FUNC_NORETURN void z_irq_spurious(const void *unused)
 {
+#ifdef CONFIG_RISCV_EMPTY_IRQ_SPURIOUS
+	while (1) {
+	}
+
+	CODE_UNREACHABLE;
+#else
 	unsigned long mcause;
 
 	ARG_UNUSED(unused);
@@ -37,6 +43,7 @@ FUNC_NORETURN void z_irq_spurious(const void *unused)
 	}
 #endif
 	z_riscv_fatal_error(K_ERR_SPURIOUS_IRQ, NULL);
+#endif
 }
 
 #ifdef CONFIG_DYNAMIC_INTERRUPTS


### PR DESCRIPTION
Add the possibility to disable fault handling in spurious interrupt handler on RISCs and replacce it with an infinite loop.